### PR TITLE
Remove dependency on `voladdress`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["log", "logging", "logger", "gba", "mgba"]
 
 [dependencies]
 log = "0.4.18"
-voladdress = "1.3.0"
 
 [dev-dependencies]
 cargo_metadata = "0.15.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ impl Write for Writer {
                 b'\n' => {
                     // For readability purposes, just start a new log line.
                     self.index = 0;
-                    // SAFETY: This is guaranteed to be write to a valid address.
+                    // SAFETY: This is guaranteed to be a write to a valid address.
                     unsafe {
                         MGBA_LOG_SEND.write_volatile(self.level);
                     }
@@ -126,7 +126,7 @@ impl Write for Writer {
                     // mGBA interprets null as the end of a line, so we replace null characters
                     // with substitute characters when they are intentionally logged.
 
-                    // SAFETY: This is guaranteed to be in-bounds.
+                    // SAFETY: This is guaranteed to be valid and in-bounds.
                     unsafe {
                         MGBA_LOG_BUFFER
                             .add(self.index as usize)
@@ -134,7 +134,7 @@ impl Write for Writer {
                     }
                 }
                 _ => {
-                    // SAFETY: This is guaranteed to be in-bounds.
+                    // SAFETY: This is guaranteed to be valid and in-bounds.
                     unsafe {
                         MGBA_LOG_BUFFER
                             .add(self.index as usize)
@@ -145,7 +145,7 @@ impl Write for Writer {
             let (index, overflowed) = self.index.overflowing_add(1);
             self.index = index;
             if overflowed {
-                // SAFETY: This is guaranteed to be write to a valid address.
+                // SAFETY: This is guaranteed to be a write to a valid address.
                 unsafe {
                     MGBA_LOG_SEND.write_volatile(self.level);
                 }
@@ -158,7 +158,7 @@ impl Write for Writer {
 impl Drop for Writer {
     /// Flushes the buffer, ensuring that the remaining bytes are sent.
     fn drop(&mut self) {
-        // SAFETY: This is guaranteed to be write to a valid address.
+        // SAFETY: This is guaranteed to be a write to a valid address.
         unsafe {
             MGBA_LOG_SEND.write_volatile(self.level);
         }


### PR DESCRIPTION
The types from `voladdress` were only used in a few places anyway, and the "safe at declaration" benefits were not really necessary; there were basically the same number of `unsafe` blocks either way. Removing this dependency has the benefit of a smaller dependency tree. 