### PR TITLE
Disable interrupts when writing to buffer.

### DIFF
--- a/tests/log.rs
+++ b/tests/log.rs
@@ -165,3 +165,26 @@ fn overflow() {
         message: "wxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz".to_owned(),
     }));
 }
+
+#[test]
+fn sync() {
+    let rom = build_rom("tests/sync");
+
+    let records = execute_rom(&rom);
+
+    assert!(records.contains(&Record {
+        level: Level::Info,
+        message: "Hello, world!".to_owned(),
+    }));
+    assert!(records.contains(&Record {
+        level: Level::Debug,
+        message: "in irq".to_owned(),
+    }));
+    // Synchronization issues will cause empty messages to be included in the output. This happens
+    // because the buffer is flushed before writing has finished, and mGBA then interprets the null
+    // character at the start of the buffer as the end of the message.
+    assert!(!records.contains(&Record {
+        level: Level::Info,
+        message: "".to_owned(),
+    }))
+}

--- a/tests/sync/.cargo/config.toml
+++ b/tests/sync/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "thumbv4t-none-eabi"
+
+[target.thumbv4t-none-eabi]
+runner = "mgba"
+rustflags = ["-Clink-arg=-Tlinker_script.ld"]
+
+[unstable]
+build-std = ["core"]

--- a/tests/sync/Cargo.toml
+++ b/tests/sync/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sync"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+gba = "0.11.2"
+log = "0.4.18"
+mgba_log = {path = "../../"}
+voladdress = "1.3.0"

--- a/tests/sync/linker_script.ld
+++ b/tests/sync/linker_script.ld
@@ -1,0 +1,99 @@
+/* THIS LINKER SCRIPT FILE IS RELEASED TO THE PUBLIC DOMAIN (SPDX: CC0-1.0) */
+
+ENTRY(__start)
+
+MEMORY {
+  ewram (w!x) : ORIGIN = 0x2000000, LENGTH = 256K
+  iwram (w!x) : ORIGIN = 0x3000000, LENGTH = 32K
+  rom (rx)    : ORIGIN = 0x8000000, LENGTH = 32M
+}
+
+SECTIONS {
+  .text : {
+    /* be sure that the ROM header is the very first */
+    *(.text.gba_rom_header);
+    *(.text .text.*);
+    . = ALIGN(4);
+  } >rom = 0x00
+
+  .rodata : {
+    *(.rodata .rodata.*);
+    . = ALIGN(4);
+  } >rom = 0x00
+
+  . = ALIGN(4);
+  __iwram_position_in_rom = .;
+  .data : {
+    __iwram_start = ABSOLUTE(.);
+    
+    *(.data .data.*);
+    *(.iwram .iwram.*);
+    . = ALIGN(4);
+    
+    __iwram_end = ABSOLUTE(.);
+  } >iwram AT>rom = 0x00
+
+  . = ALIGN(4);
+  __ewram_position_in_rom = __iwram_position_in_rom + (__iwram_end - __iwram_start);
+  .ewram : {
+    __ewram_start = ABSOLUTE(.);
+    
+    *(.ewram .ewram.*);
+    . = ALIGN(4);
+    
+    __ewram_end = ABSOLUTE(.);
+  } >ewram AT>rom = 0x00
+
+  . = ALIGN(4);
+  __bss_position_in_rom = __ewram_position_in_rom + (__ewram_end - __ewram_start);
+  .bss : {
+    __bss_start = ABSOLUTE(.);
+
+    *(.bss .bss.*);
+    . = ALIGN(4);
+
+    __bss_end = ABSOLUTE(.);
+  } >iwram
+
+  __iwram_word_copy_count = (__iwram_end - __iwram_start) / 4;
+  __ewram_word_copy_count = (__ewram_end - __ewram_start) / 4;
+  __bss_word_clear_count = (__bss_end - __bss_start) / 4;
+
+  /* rust-lld demands we keep the `section header string table` */
+  .shstrtab        0 : { *(.shstrtab) }
+
+  /* debugging sections */
+  /* Stabs */
+  .stab            0 : { *(.stab) }
+  .stabstr         0 : { *(.stabstr) }
+  .stab.excl       0 : { *(.stab.excl) }
+  .stab.exclstr    0 : { *(.stab.exclstr) }
+  .stab.index      0 : { *(.stab.index) }
+  .stab.indexstr   0 : { *(.stab.indexstr) }
+  .comment         0 : { *(.comment) }
+  /* DWARF 1 */
+  .debug           0 : { *(.debug) }
+  .line            0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo   0 : { *(.debug_srcinfo) }
+  .debug_sfnames   0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges   0 : { *(.debug_aranges) }
+  .debug_pubnames  0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info      0 : { *(.debug_info) }
+  .debug_abbrev    0 : { *(.debug_abbrev) }
+  .debug_line      0 : { *(.debug_line) }
+  .debug_frame     0 : { *(.debug_frame) }
+  .debug_str       0 : { *(.debug_str) }
+  .debug_loc       0 : { *(.debug_loc) }
+  .debug_macinfo   0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+
+  /* discard anything not already mentioned */
+  /DISCARD/ : { *(*) }
+}

--- a/tests/sync/src/main.rs
+++ b/tests/sync/src/main.rs
@@ -3,7 +3,12 @@
 
 extern crate gba;
 
-use gba::{asm_runtime::RUST_IRQ_HANDLER, interrupts::IrqBits, mmio::{DISPSTAT, IE, IME}, video::DisplayStatus};
+use gba::{
+    asm_runtime::RUST_IRQ_HANDLER,
+    interrupts::IrqBits,
+    mmio::{DISPSTAT, IE, IME},
+    video::DisplayStatus,
+};
 use voladdress::{Safe, VolAddress};
 
 /// This address is used to communicate the current execution status directly with the test runner.
@@ -16,7 +21,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[link_section = ".iwram"]
 extern "C" fn irq_handler(_: IrqBits) {
-  log::debug!("in irq");
+    log::debug!("in irq");
 }
 
 #[no_mangle]

--- a/tests/sync/src/main.rs
+++ b/tests/sync/src/main.rs
@@ -1,0 +1,38 @@
+#![no_std]
+#![no_main]
+
+extern crate gba;
+
+use gba::{asm_runtime::RUST_IRQ_HANDLER, interrupts::IrqBits, mmio::{DISPSTAT, IE, IME}, video::DisplayStatus};
+use voladdress::{Safe, VolAddress};
+
+/// This address is used to communicate the current execution status directly with the test runner.
+const STATUS_REGISTER: VolAddress<u8, Safe, Safe> = unsafe { VolAddress::new(0x0203FFFF) };
+
+#[panic_handler]
+fn panic_handler(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[link_section = ".iwram"]
+extern "C" fn irq_handler(_: IrqBits) {
+  log::debug!("in irq");
+}
+
+#[no_mangle]
+pub fn main() {
+    mgba_log::init().expect("unable to initialize");
+
+    RUST_IRQ_HANDLER.write(Some(irq_handler));
+    DISPSTAT.write(DisplayStatus::new().with_irq_vblank(true));
+    IE.write(IrqBits::VBLANK);
+    IME.write(true);
+
+    for _ in 0..1000 {
+        log::info!("Hello, world!");
+    }
+
+    STATUS_REGISTER.write(3);
+
+    loop {}
+}


### PR DESCRIPTION
This fixes #4.

From everything I read today, this seems to be the proper recommended solution for this kind of thing. Since the buffer is a shared resource, we can effectively "claim" it by disabling interrupts. There are no separate threads on GBA, so this is the only thing we need to worry about regarding shared access. When interrupts are reenabled, any interrupts that triggered will be handled at that time.