### PR TITLE
Mark `init()` as an `unsafe` function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Changed
+- Marked `init()` as `unsafe`.
 
 ## 0.2.0 - 2023-06-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Changed
 - Marked `init()` as `unsafe`.
+### Fixed
+- Synchronization bug when using the `fatal!` macro.
 
 ## 0.2.0 - 2023-06-10
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["development-tools::debugging", "game-development", "no-std", "no-
 keywords = ["log", "logging", "logger", "gba", "mgba"]
 
 [dependencies]
-log = "0.4.18"
+log = "0.4.19"
 
 [dev-dependencies]
 cargo_metadata = "0.15.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,16 @@ static LOGGER: Logger = Logger;
 /// This function returns `Ok(())` if the logger was enabled. If the logger was not enabled for any
 /// reason, it instead returns an [`Error`]. See the documentation for [`Error`] for what errors
 /// can occur.
-pub fn init() -> Result<(), Error> {
+///
+/// # Safety
+/// This function binds mGBA's [memory mapped debug IO registers](
+/// https://github.com/mgba-emu/mgba/blob/17a549baf2c8100f2c7e7c244996d9ac85d23198/opt/libgba/mgba.c#L31-L33)
+/// to the global logger. No other code may access the debug registers *unless* that code can
+/// guarantee it has exclusive access to the registers, meaning its access cannot ever be
+/// interrupted by a [`log`] call. Failure to do so will cause undefined behavior in the form of a
+/// [data race](https://doc.rust-lang.org/nomicon/races.html), likely resulting in garbage being
+/// logged.
+pub unsafe fn init() -> Result<(), Error> {
     // SAFETY: This is guaranteed to be a valid write.
     unsafe {
         MGBA_LOG_ENABLE.write(0xC0DE);

--- a/tests/debug/src/main.rs
+++ b/tests/debug/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     log::debug!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/error/src/main.rs
+++ b/tests/error/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     log::error!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/fatal/src/main.rs
+++ b/tests/fatal/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     mgba_log::fatal!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/info/src/main.rs
+++ b/tests/info/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     log::info!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/new_line/src/main.rs
+++ b/tests/new_line/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     log::info!("Hello,\nworld!");
 
     STATUS_REGISTER.write(3);

--- a/tests/null/src/main.rs
+++ b/tests/null/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     log::info!("\x00");
 
     STATUS_REGISTER.write(3);

--- a/tests/overflow/src/main.rs
+++ b/tests/overflow/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     log::info!("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
 
     STATUS_REGISTER.write(3);

--- a/tests/sync/src/main.rs
+++ b/tests/sync/src/main.rs
@@ -26,7 +26,7 @@ extern "C" fn irq_handler(_: IrqBits) {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
 
     RUST_IRQ_HANDLER.write(Some(irq_handler));
     DISPSTAT.write(DisplayStatus::new().with_irq_vblank(true));

--- a/tests/trace/src/main.rs
+++ b/tests/trace/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     log::trace!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/warn/src/main.rs
+++ b/tests/warn/src/main.rs
@@ -13,7 +13,7 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 
 #[no_mangle]
 pub fn main() {
-    mgba_log::init().expect("unable to initialize");
+    unsafe { mgba_log::init() }.expect("unable to initialize");
     log::warn!("Hello, world!");
 
     STATUS_REGISTER.write(3);


### PR DESCRIPTION
There are two things to consider here:

1. This crate directly accesses the debug registers in a global setting. While #5 resolved the issue of multiple global logs happening at the same time, it cannot resolve the issue of external code accessing these registers without any protection and being interrupted in the process. After #5, this actually will not affect the performance of this crate (as no external library's code can interrupt the logging), but there is nothing that can be done to prevent logging from overwriting some other library's write.
2. As was discovered with the release of `log` version `0.4.19`, the proper log initialization functions to be used here are the racy functions (see [discussion](https://github.com/rust-lang/log/issues/567) after the release of this version). Version `0.4.19` corrected the previous error, meaning we now need to explicitly initialize this logger in a racy manner. Therefore, the safety concerns must apply to the `init()` function as well.

While the first point may not actually be enough to consider this function as `unsafe`, since no write performed by the logging can ever itself be overwritten in a data race, and it can be argued that other code accessing these same registers in an unsafe fashion should be the ones marking themselves as `unsafe`, in practice this isn't the case in the ecosystem currently, and it is incredibly difficult to reason about safe access to MMIO at all. Therefore, it should definitely at least be mentioned in the safety documentation. However, the second point *definitely* makes this function `unsafe`, as there are no interrupt protections currently built in for intitialization.