### PR TITLE
Configure `init()` to be safe again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
 ## Unreleased
-### Changed
-- Marked `init()` as `unsafe`.
 ### Fixed
 - Synchronization bug when using the `fatal!` macro.
+- `init()` now safely initializes the logger by disabling interrupts.
 
 ## 0.2.0 - 2023-06-10
 ### Changed

--- a/tests/debug/src/main.rs
+++ b/tests/debug/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     log::debug!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/error/src/main.rs
+++ b/tests/error/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     log::error!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/fatal/src/main.rs
+++ b/tests/fatal/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     mgba_log::fatal!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/info/src/main.rs
+++ b/tests/info/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     log::info!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/new_line/src/main.rs
+++ b/tests/new_line/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     log::info!("Hello,\nworld!");
 
     STATUS_REGISTER.write(3);

--- a/tests/null/src/main.rs
+++ b/tests/null/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     log::info!("\x00");
 
     STATUS_REGISTER.write(3);

--- a/tests/overflow/src/main.rs
+++ b/tests/overflow/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     log::info!("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
 
     STATUS_REGISTER.write(3);

--- a/tests/sync/src/main.rs
+++ b/tests/sync/src/main.rs
@@ -19,6 +19,9 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
+#[no_mangle]
+pub fn __sync_synchronize() {}
+
 #[link_section = ".iwram"]
 extern "C" fn irq_handler(_: IrqBits) {
     log::debug!("in irq");
@@ -26,7 +29,7 @@ extern "C" fn irq_handler(_: IrqBits) {
 
 #[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
 
     RUST_IRQ_HANDLER.write(Some(irq_handler));
     DISPSTAT.write(DisplayStatus::new().with_irq_vblank(true));

--- a/tests/trace/src/main.rs
+++ b/tests/trace/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     log::trace!("Hello, world!");
 
     STATUS_REGISTER.write(3);

--- a/tests/warn/src/main.rs
+++ b/tests/warn/src/main.rs
@@ -12,8 +12,11 @@ fn panic_handler(_: &core::panic::PanicInfo) -> ! {
 }
 
 #[no_mangle]
+pub fn __sync_synchronize() {}
+
+#[no_mangle]
 pub fn main() {
-    unsafe { mgba_log::init() }.expect("unable to initialize");
+    mgba_log::init().expect("unable to initialize");
     log::warn!("Hello, world!");
 
     STATUS_REGISTER.write(3);


### PR DESCRIPTION
This removes the `unsafe` from `init()` that was added in #8. There are two things to consider here:

1. After further research, it's been determined that the use of the debug registers by other code does not pose a data race, but simply a race condition. Meaning each write to an individual byte cannot be interrupted, and therefore each write cannot be a race. It is still important for this library to ensure log calls disable `IME`, for the same reasons set forth in #4, but the fact that this code can overwrite data set by other code is not technically a data race, and therefore not `unsafe`.
2. This PR disables `IME` when setting the logger and max level, making those calls safe. This is what all user code should have done after #8 anyways (and before, since apparently the log initialization functions were likely not working correctly prior to `log 0.4.19`), so it makes more sense to simply handle it here.